### PR TITLE
ZPM in a separate database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,40 @@ ARG IMAGE=store/intersystems/iris-community:2019.4.0.383.0
 ARG DEV=0
 FROM $IMAGE
 
+RUN \
+  wget -q https://pm.community.intersystems.com/packages/zpm/latest/installer -O /tmp/zpm.xml && \
+  mkdir /usr/irissys/mgr/zpm && \
+  iris start $ISC_PACKAGE_INSTANCENAME quietly && \
+  /bin/echo -e \
+    "set pNS(\"Globals\")=\"%DEFAULTDB\"\n" \
+    "set sc=##class(Config.Namespaces).Create(\"%ALL\",.pNS)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set pDB(\"Directory\")=\"/usr/irissys/mgr/zpm/\"\n" \
+    "set sc=##class(SYS.Database).CreateDatabase(\"/usr/irissys/mgr/zpm/\")\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set sc=##class(Config.Databases).Create(\"ZPM\",.pDB)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set pMap(\"Database\")=\"ZPM\"\n" \
+    "set sc=##Class(Config.MapPackages).Create(\"%ALL\",\"%ZPM\",.pMap)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set sc=##Class(Config.MapGlobals).Create(\"%ALL\",\"%ZPM.*\",.pMap)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set sc=##Class(Config.MapGlobals).Create(\"%SYS\",\"ZPM.*\",.pMap)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%ZPM.*\",.pMap)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%ZLANGF00\",.pMap)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%ZLANGC00\",.pMap)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set sc = ##class(%SYSTEM.OBJ).Load(\"/tmp/zpm.xml\", \"c/multicompile=0\")\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "halt" \
+  | iris session $ISC_PACKAGE_INSTANCENAME -U %SYS && \
+  iris stop $ISC_PACKAGE_INSTANCENAME quietly
+
+FROM $IMAGE
+
 USER root
 
 WORKDIR /opt/irisapp
@@ -10,18 +44,5 @@ RUN chown ${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} /opt/irisapp
 
 USER irisowner
 
-RUN \
-  wget -q https://pm.community.intersystems.com/packages/zpm/latest/installer -O /tmp/zpm.xml && \
-  iris start $ISC_PACKAGE_INSTANCENAME quietly && \
-  /bin/echo -e \
-    "Do ##class(%SYSTEM.OBJ).Load(\"/tmp/zpm.xml\", \"ck\")\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "do ##class(SYS.Container).QuiesceForBundling()\n" \
-    "halt" \
-  | iris session $ISC_PACKAGE_INSTANCENAME -U %SYS && \
-  iris stop $ISC_PACKAGE_INSTANCENAME quietly && \
-  rm -rf /usr/irissys/mgr/IRIS.WIJ; \
-  rm -rf /usr/irissys/mgr/journal/*; \
-  rm -rf /usr/irissys/mgr/stream/*; \
-  rm -rf /usr/irissys/mgr/iristemp/*; \
-  rm /tmp/zpm.xml
+COPY --from=0 --chown=irisowner:irisuser /usr/irissys/iris.cpf /usr/irissys/iris.cpf
+COPY --from=0 --chown=irisowner:irisuser /usr/irissys/mgr/zpm /usr/irissys/mgr/zpm


### PR DESCRIPTION
To reduce the final image size, made ZPM deployed separately, in own namespace with mapping through %ALL namespace.
So, now it just only 22 MB

As a side-effect of this, IRIS will have %ALL namespace by default.