### PR TITLE
support ipm from embedded python

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 **
 !docker-entrypoint.sh
 !iriscli
+!iris_ipm.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,10 @@ COPY --from=0 --chown=${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} /usr/iriss
 
 ENV PATH="$PATH:/home/irisowner/.local/bin"
 
-RUN pip install irissqlcli
+COPY iris_ipm.py /usr/irissys/lib/python/
+
+RUN pip install irissqlcli && \
+    cat /usr/irissys/lib/python/iris_ipm.py >> /usr/irissys/lib/python/iris.py
 
 COPY iriscli /home/irisowner/bin/
 
@@ -88,7 +91,10 @@ COPY --from=0 --chown=${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} /usr/iriss
 
 ENV PATH="$PATH:/home/irisowner/.local/bin"
 
-RUN pip install irissqlcli
+COPY iris_ipm.py /usr/irissys/lib/python/
+
+RUN pip install irissqlcli && \
+    cat /usr/irissys/lib/python/iris_ipm.py >> /usr/irissys/lib/python/iris.py
 
 COPY iriscli /home/irisowner/bin/
 

--- a/iris_ipm.py
+++ b/iris_ipm.py
@@ -1,0 +1,41 @@
+def ipm(cmd, *args):
+    """
+    Executes shell command with IPM:
+
+    Parameters
+    ----------
+    cmd : str
+        The command to execute
+
+    Examples
+    --------
+    `ipm('help')`
+    `ipm('load /home/irisowner/dev -v')`
+    `ipm('install webterminal')`
+    """
+
+    import multiprocessing
+
+    def shell(cmd, status):
+        import iris
+
+        status.put(True)
+
+        res = iris.cls("%ZPM.PackageManager").Shell(cmd)
+        print('')
+        if res != 1:
+            status.get()
+            status.put(False)
+
+    manager = multiprocessing.Manager()
+    status = manager.Queue()
+    process = multiprocessing.Process(
+        target=shell,
+        args=(
+            cmd,
+            status,
+        ),
+    )
+    process.start()
+    process.join()
+    return status.get()


### PR DESCRIPTION
Added support for IPM, from embedded python, with this, it will be possible to use it like this

```python
from iris import ipm

assert ipm('load /home/irisowner/dev -v')

assert ipm('list')
```