### PR TITLE
Updates for 0.9.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !docker-entrypoint.sh
 !iriscli
 !iris_ipm.py
+!iris.script

--- a/Dockerfile-phase1
+++ b/Dockerfile-phase1
@@ -1,10 +1,11 @@
-ARG IMAGE=containers.intersystems.com/intersystems/iris-community:2022.2.0.368.0
-ARG IMAGEARM=containers.intersystems.com/intersystems/iris-community-arm64:2022.2.0.368.0
+ARG IMAGE=intersystems/iris-community:latest-cd
 ARG DEV=0
 FROM $IMAGE
 
+ARG IPM_INSTALLER=https://pm.community.intersystems.com/packages/zpm/latest/installer
+
 RUN \
-  wget -q https://pm.community.intersystems.com/packages/zpm/latest/installer -O /tmp/zpm.xml && \
+  wget -q $IPM_INSTALLER -O /tmp/zpm.xml && \
   mkdir /usr/irissys/mgr/zpm && \
   iris start $ISC_PACKAGE_INSTANCENAME quietly && \
   /bin/echo -e \
@@ -13,29 +14,38 @@ RUN \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
     "set pDB(\"Directory\")=\"/usr/irissys/mgr/zpm/\"\n" \
     "set sc=##class(SYS.Database).CreateDatabase(pDB(\"Directory\"), 30)\n" \
-    "do ##class(SYS.Database).MountDatabase(pDB(\"Directory\"))" \
+    "do ##class(SYS.Database).MountDatabase(pDB(\"Directory\"))\n" \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##class(Config.Databases).Create(\"ZPM\",.pDB)\n" \
+    "set sc=##class(Config.Databases).Create(\"IPM\",.pDB)\n" \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set pMap(\"Database\")=\"ZPM\"\n" \
-    "set sc=##Class(Config.MapPackages).Create(\"%ALL\",\"%ZPM\",.pMap)\n" \
+    "set pNamespace(\"Globals\")=\"IPM\"\n" \
+    "set pNamespace(\"Routines\")=\"IPM\"\n" \
+    "set sc=##Class(Config.Namespaces).Create(\"IPM\",.pNamespace)\n" \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##Class(Config.MapGlobals).Create(\"%ALL\",\"%ZPM.*\",.pMap)\n" \
+    "set pMap(\"Database\")=\"IPM\"\n" \
+    "set sc=##Class(Config.MapPackages).Create(\"%ALL\",\"%IPM\",.pMap)\n" \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##Class(Config.MapGlobals).Create(\"%SYS\",\"ZPM.*\",.pMap)\n" \
+    "set sc=##Class(Config.MapPackages).Create(\"%ALL\",\"IPM\",.pMap)\n" \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%ZPM.*\",.pMap)\n" \
+    "set sc=##Class(Config.MapGlobals).Create(\"%ALL\",\"%IPM.*\",.pMap)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set sc=##Class(Config.MapGlobals).Create(\"%SYS\",\"IPM.*\",.pMap)\n" \
+    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%IPM.*\",.pMap)\n" \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
     "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%ZLANGF00\",.pMap)\n" \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
     "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%ZLANGC00\",.pMap)\n" \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
+    "zn \"IPM\"\n" \
     "set sc = ##class(%SYSTEM.OBJ).Load(\"/tmp/zpm.xml\", \"c\")\n" \
     "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "do ##class(SYS.Database).Defragment(pDB(\"Directory\"))" \
-    "do ##class(SYS.Database).CompactDatabase(pDB(\"Directory\"),100)" \
-    "do ##class(SYS.Database).ReturnUnusedSpace(pDB(\"Directory\"))" \
-    "do ##class(SYS.Database).DismountDatabase(pDB(\"Directory\"))" \
-    "halt" \
+    "zn \"%SYS\"\n" \
+    "do ##class(Config.Namespaces).Delete(\"IPM\")\n" \
+    "do ##class(SYS.Database).Defragment(pDB(\"Directory\"))\n" \
+    "do ##class(SYS.Database).CompactDatabase(pDB(\"Directory\"),100)\n" \
+    "do ##class(SYS.Database).ReturnUnusedSpace(pDB(\"Directory\"))\n" \
+    "do ##class(SYS.Database).DismountDatabase(pDB(\"Directory\"))\n" \
+    "halt\n" \
   | iris session $ISC_PACKAGE_INSTANCENAME -U %SYS && \
   iris stop $ISC_PACKAGE_INSTANCENAME quietly

--- a/Dockerfile-phase1
+++ b/Dockerfile-phase1
@@ -4,48 +4,11 @@ FROM $IMAGE
 
 ARG IPM_INSTALLER=https://pm.community.intersystems.com/packages/zpm/latest/installer
 
+COPY ./iris.script /tmp/iris.script
+
 RUN \
   wget -q $IPM_INSTALLER -O /tmp/zpm.xml && \
   mkdir /usr/irissys/mgr/zpm && \
   iris start $ISC_PACKAGE_INSTANCENAME quietly && \
-  /bin/echo -e \
-    "set pNS(\"Globals\")=\"%DEFAULTDB\"\n" \
-    "set sc=##class(Config.Namespaces).Create(\"%ALL\",.pNS)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set pDB(\"Directory\")=\"/usr/irissys/mgr/zpm/\"\n" \
-    "set sc=##class(SYS.Database).CreateDatabase(pDB(\"Directory\"), 30)\n" \
-    "do ##class(SYS.Database).MountDatabase(pDB(\"Directory\"))\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##class(Config.Databases).Create(\"IPM\",.pDB)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set pNamespace(\"Globals\")=\"IPM\"\n" \
-    "set pNamespace(\"Routines\")=\"IPM\"\n" \
-    "set sc=##Class(Config.Namespaces).Create(\"IPM\",.pNamespace)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set pMap(\"Database\")=\"IPM\"\n" \
-    "set sc=##Class(Config.MapPackages).Create(\"%ALL\",\"%IPM\",.pMap)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##Class(Config.MapPackages).Create(\"%ALL\",\"IPM\",.pMap)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##Class(Config.MapGlobals).Create(\"%ALL\",\"%IPM.*\",.pMap)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##Class(Config.MapGlobals).Create(\"%SYS\",\"IPM.*\",.pMap)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%IPM.*\",.pMap)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%ZLANGF00\",.pMap)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "set sc=##Class(Config.MapRoutines).Create(\"%ALL\",\"%ZLANGC00\",.pMap)\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "zn \"IPM\"\n" \
-    "set sc = ##class(%SYSTEM.OBJ).Load(\"/tmp/zpm.xml\", \"c\")\n" \
-    "if '\$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)\n" \
-    "zn \"%SYS\"\n" \
-    "do ##class(Config.Namespaces).Delete(\"IPM\")\n" \
-    "do ##class(SYS.Database).Defragment(pDB(\"Directory\"))\n" \
-    "do ##class(SYS.Database).CompactDatabase(pDB(\"Directory\"),100)\n" \
-    "do ##class(SYS.Database).ReturnUnusedSpace(pDB(\"Directory\"))\n" \
-    "do ##class(SYS.Database).DismountDatabase(pDB(\"Directory\"))\n" \
-    "halt\n" \
-  | iris session $ISC_PACKAGE_INSTANCENAME -U %SYS && \
+  iris session $ISC_PACKAGE_INSTANCENAME -U %SYS < /tmp/iris.script && \
   iris stop $ISC_PACKAGE_INSTANCENAME quietly

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ The published images could be found at following Docker Repositories:
 [InterSystems IRIS Community Edition](https://hub.docker.com/r/intersystemsdc/iris-community)
 [InterSystems IRIS Community Edition for Health:](https://hub.docker.com/r/intersystemsdc/irishealth-community)
 
-Current version of [ZPM installed](https://openexchange.intersystems.com/package/ObjectScript-Package-Manager-2): 0.7.0
+Current version of [IPM installed](https://openexchange.intersystems.com/package/InterSystems-Package-Manager-1): 0.9.0

--- a/docker-compose-beta.yml
+++ b/docker-compose-beta.yml
@@ -1,0 +1,16 @@
+version: '3.6'
+services:
+  iris:
+    build: 
+      context: .
+      dockerfile: Dockerfile-amd64
+      args:
+        IPM_INSTALLER: https://github.com/intersystems/ipm/releases/download/v0.9.0-beta.31/zpm-0.9.0-beta.31.xml
+    restart: always
+    ports: 
+      - 1972
+      - 57774:52773
+      - 53773
+    volumes:
+      - ~/iris.key:/usr/irissys/mgr/iris.key
+      - ./:/irisdev/app

--- a/iris.script
+++ b/iris.script
@@ -18,6 +18,8 @@ set sc=##Class(Config.MapPackages).Create("%ALL","IPM",.pMap)
 if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
 set sc=##Class(Config.MapGlobals).Create("%ALL","%IPM.*",.pMap)
 if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set sc=##Class(Config.MapGlobals).Create("%ALL","IPM.Repo.*",.pMap)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
 set sc=##Class(Config.MapGlobals).Create("%SYS","IPM.*",.pMap)
 if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
 set sc=##Class(Config.MapRoutines).Create("%ALL","%IPM.*",.pMap)
@@ -29,6 +31,7 @@ if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
 zn "IPM"
 set sc = ##class(%SYSTEM.OBJ).Load("/tmp/zpm.xml", "c")
 if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+zpm "repo -reset-defaults"
 zn "%SYS"
 do ##class(Config.Namespaces).Delete("IPM")
 do ##class(SYS.Database).Defragment(pDB("Directory"))

--- a/iris.script
+++ b/iris.script
@@ -1,0 +1,38 @@
+set pNS("Globals")="%DEFAULTDB"
+set sc=##class(Config.Namespaces).Create("%ALL",.pNS)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set pDB("Directory")="/usr/irissys/mgr/zpm/"
+set sc=##class(SYS.Database).CreateDatabase(pDB("Directory"), 30)
+do ##class(SYS.Database).MountDatabase(pDB("Directory"))
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set sc=##class(Config.Databases).Create("IPM",.pDB)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set pNamespace("Globals")="IPM"
+set pNamespace("Routines")="IPM"
+set sc=##Class(Config.Namespaces).Create("IPM",.pNamespace)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set pMap("Database")="IPM"
+set sc=##Class(Config.MapPackages).Create("%ALL","%IPM",.pMap)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set sc=##Class(Config.MapPackages).Create("%ALL","IPM",.pMap)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set sc=##Class(Config.MapGlobals).Create("%ALL","%IPM.*",.pMap)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set sc=##Class(Config.MapGlobals).Create("%SYS","IPM.*",.pMap)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set sc=##Class(Config.MapRoutines).Create("%ALL","%IPM.*",.pMap)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set sc=##Class(Config.MapRoutines).Create("%ALL","%ZLANGF00",.pMap)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+set sc=##Class(Config.MapRoutines).Create("%ALL","%ZLANGC00",.pMap)
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+zn "IPM"
+set sc = ##class(%SYSTEM.OBJ).Load("/tmp/zpm.xml", "c")
+if '$Get(sc,1) do ##class(%SYSTEM.Process).Terminate(, 1)
+zn "%SYS"
+do ##class(Config.Namespaces).Delete("IPM")
+do ##class(SYS.Database).Defragment(pDB("Directory"))
+do ##class(SYS.Database).CompactDatabase(pDB("Directory"),100)
+do ##class(SYS.Database).ReturnUnusedSpace(pDB("Directory"))
+do ##class(SYS.Database).DismountDatabase(pDB("Directory"))
+halt

--- a/iris_ipm.py
+++ b/iris_ipm.py
@@ -21,7 +21,7 @@ def ipm(cmd, *args):
 
         status.put(True)
 
-        res = iris.cls("%ZPM.PackageManager").Shell(cmd)
+        res = iris.cls("%IPM.Main").Shell(cmd)
         print('')
         if res != 1:
             status.get()


### PR DESCRIPTION
This covers the %ZPM->%IPM rename and some backwards-incompatible default behaviors around namespace segmentation to keep things as seamless as possible.

NOTE: this shouldn't go forward prior to IPM 0.9.0 release, or could work around by not having IPM_INSTALLER point to the "latest" (possibly breaking compatibility) version.