### PR TITLE
pick up 2024.3 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ env:
     latest-cd
     2024.1
     2024.2
+    2024.3
     2023.1.4.580.0
   preview: latest-preview
 jobs:

--- a/Dockerfile-vecdb
+++ b/Dockerfile-vecdb
@@ -1,1 +1,0 @@
-FROM caretdev/iris-community:2024.1-vecdb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zpm-dockerhub
 repository for baking zpm enabled images for InterSystems IRIS
-Latest IRIS Version 2024.2.0.247 and IRIS for Health 2024.2.0.247
+Latest IRIS Version 2024.3.0.217.0 and IRIS for Health 2024.3.0.217.0
 
 ![CI](https://github.com/intersystems-community/zpm-dockerhub/workflows/CI/badge.svg)
 


### PR DESCRIPTION
Minor edits to support this month's 2024.3 release

@evshvarov : I ran into a few references to earlier releases:
- `Dockerfile` references a 2024.1 build (twice)
- `Dockerfile-phase1` references a 2022.2 build
I'm assuming these are not relevant / overruled when building the actual images, but in that case maybe the references can be removed to avoid confusion?